### PR TITLE
Suggestion: add default binding for result function

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ import React from 'react';
 import { createSelector } from 'reselect';
 import { connect } from 'redux/react';
 
+const shopItemSelector = createSelector(state => state.shop.items);
+
 const subtotalSelector = createSelector(
-  [state => state.shop.items],
+  shopItemSelector,
   items => items.reduce((acc, item) => acc + item.value, 0)
 );
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
+const identitySelector = state => state;
+
 export function createSelectorCreator(valueEquals) {
-    return (selectors, resultFunc) => {
+    return (selectors, resultFunc = identitySelector) => {
         if (!Array.isArray(selectors)) {
             selectors = [selectors];
         }

--- a/test/test_selector.js
+++ b/test/test_selector.js
@@ -13,6 +13,10 @@ suite('selector', function() {
             [state => state.a, state => state.b], (a, b) => a + b);
         assert.equal(selector({a: 1, b: 2}), 3);
     });
+    test("default result function", function() {
+        const selector = createSelector([state => state.a]);
+        assert.equal(selector({a: 1}), 1);
+    });
     test("first argument does not need to be an array", function() {
         const selector = createSelector(
             state => state.a, a => a);


### PR DESCRIPTION
As the base case for selectors is often to only extract a field of the current state it is quite handy to bind the result function to the identity function.

The question is whether it makes sense binding the identity function to the result function or to suggest that the user should specify default selectors as plain functions (e.g. in the README const shoptItemSelector = state => state.shop.items)