### PR TITLE
Minor perf improvements

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,8 +38,5 @@ function memoize(func, valueEquals) {
 }
 
 function argsEquals(a, b, valueEquals) {
-    if (a.length != b.length) {
-        return false;
-    }
     return a.every((value, index) => valueEquals(value, b[index]));
 }

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ export function createSelectorCreator(valueEquals) {
         const memoizedResultFunc = memoize(resultFunc, valueEquals);
         return state => {
             const params = selectors.map(selector => selector(state));
-            return memoizedResultFunc(...params);
+            return memoizedResultFunc(params);
         }
     };
 }
@@ -27,7 +27,7 @@ export function defaultValueEquals(a, b) {
 function memoize(func, valueEquals) {
     let lastArgs = null;
     let lastResult = null;
-    return (...args) => {
+    return (args) => {
         if (lastArgs !== null && argsEquals(args, lastArgs, valueEquals)) {
             return lastResult;
         }


### PR DESCRIPTION
First one should close #8. Second one just makes sense to me: we create params as an array, then spread it to memoize only to have memoize coerce it back to an array. Compile with babel and check out how much extraneous code it generates.