### PR TITLE
WIP 0.0.3 (Configurable memoize / variadic dependencies / pass props to selector)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,12 @@
+{
+  "extends": "eslint-config-airbnb",
+  "env": {
+    "browser": true,
+    "mocha": true,
+    "node": true
+  },
+  "rules": {
+    "block-scoped-var": 0,
+    "indent": [2, 4]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Simple "selector" library for Redux inspired by getters in [NuclearJS](https://g
 
 ### Selector Definitions
 selectors/ShopSelectors.js
-```Javascript
+```js
 
 /* 
 The data in the Redux store has the following shape:
@@ -57,40 +57,42 @@ const taxPercentSelector = state => state.shop.taxPercent;
  * In all other cases the precomputed values are returned.
  */
 const subtotalSelector = createSelector(
-  [shopItemsSelector],
+  shopItemsSelector,
   items => items.reduce((acc, item) => acc + item.value, 0)
 );
 
 const taxSelector = createSelector(
-  [subtotalSelector, taxPercentSelector],
+  subtotalSelector,
+  taxPercentSelector,
   (subtotal, taxPercent) => subtotal * (taxPercent / 100)
 );
 
 export const totalSelector = createSelector(
-  [subtotalSelector, taxSelector],
+  subtotalSelector,
+  taxSelector,
   (subtotal, tax) => { return {total: subtotal + tax}}
 );
 ```
 
 You can use a factory function when you need additional arguments for your selectors:
 
-```Javascript
+```js
 const expensiveItemSelectorFactory = minValue => {
   return createSelector(
-    [shopItemsSelector],
+    shopItemsSelector,
     items => items.filter(item => item.value < minValue)
   );
 }
 
 const subtotalSelector = createSelector(
-  [expensiveItemSelectorFactory(200)],
+  expensiveItemSelectorFactory(200),
   items => items.reduce((acc, item) => acc + item.value, 0)
 );
 ```
 
-### Selector Usage
+### Using Selectors with React-redux
 
-```Javascript
+```js
 
 import React from 'react';
 import { connect } from 'react-redux';
@@ -121,34 +123,91 @@ export default Total;
 
 ### createSelector([inputSelectors], resultFn)
 
-Takes an array of selectors whose values are computed and passed as arguments to resultFn.
+Takes a variable number of selectors whose values are computed and passed as arguments to resultFn. A selector has the signature (state, props) => state.
 ```js
 
 const mySelector = createSelector(
-  [
+  state => state.values.value1,
+  state => state.values.value2,
+  (value1, value2) => value1 + value2
+);
+
+// You can also pass an array of selectors
+const totalSelector = createSelector(
+  [ 
     state => state.values.value1,
     state => state.values.value2
   ],
   (value1, value2) => value1 + value2
 );
 
-// it is not necessary to wrap a single input selector in an array
-const totalSelector = createSelector(
-  state => state.shop.items,
-  items => items.reduce((acc, item) => acc + item.value, 0)
+// A selector is also passed props
+const selectorWithProps = createSelector(
+  state => state.values.value1,
+  state => state.values.value2,
+  (value1, value2, props) => value1 + value2 + props.value3
 );
 
+// A selector created with createSelector ignores the props for memoization
+let called = 0;
+const selector = createSelector(
+  state => state.a,
+  (a, b) => {
+    called++;
+    return a + b
+  }
+);
+assert.equal(selector({a: 1}, 100), 101);
+assert.equal(selector({a: 1}, 200), 101);
+assert.equal(called, 1);
+assert.equal(selector({a: 2}, 200), 202);
+assert.equal(called, 2);
 ```
-### createSelectorCreator(valueEqualsFn)
-Return a selectorCreator that creates selectors with a non-default valueEqualsFn. The valueEqualsFn is used to check if the arguments to a selector have changed. The default valueEqualsFn function is:
+
+### defaultMemoizeFunc(func, valueEquals = defaultValueEquals)
+
+`defaultMemoizeFunc` has a cache size of 1. This means it always recalculates when an argument changes, as it only stores the result for immediately preceding value of the argument.
+
+`defaultMemoizeFunc` determines if an argument has changed by calling the valueEquals function. The default `valueEquals` function checks for changes using reference equality:
+
 ```js
-function defaultValueEquals(a, b) {
-  return a === b;
+function defaultValueEquals(currentVal, previousVal) {
+  return currentVal === previousVal;
 }
 ```
+
 ```js
+  let called = 0;
+  const memoized = defaultMemoize(state => {
+    called++;
+    return state.a;
+  });
+  const o1 = {a: 1};
+  const o2 = {a: 2};
+  assert.equal(memoized(o1, {}), 1);
+  assert.equal(memoized(o1, {}), 1);
+  assert.equal(called, 1);
+  assert.equal(memoized(o2, {}), 2);
+  assert.equal(called, 2);
+```
+
+
+### createSelectorCreator(memoizeFunc = defaultMemoizeFunc, ...memoizeOptions)
+
+Return a selectorCreator that creates selectors with a non-default memoizeFunc. 
+
+You can use createSelectorCreator to customize the `valueEquals` function for `defaultMemoizeFunc` like this:
+
+```js
+import { createSelectorCreator, defaultMemoizeFunc } from 'reselect';
+import Immutable from 'immutable';
+
 // create a "selector creator" that uses Immutable.is instead of ===
-const immutableCreateSelector = createSelectorCreator(Immutable.is);
+// Note that this is not usually necessary when using Immutable.js with reselect
+const immutableCreateSelector = createSelectorCreator(
+  defaultMemoizeFunc,
+  Immutable.is
+);
 
 // use the new "selector creator" to create a 
 // selector (state.values is an Immutable.List)
@@ -156,4 +215,28 @@ const mySelector = immutableCreateSelector(
   [state => state.values.filter(val => val < 5)],
   values => values.reduce((acc, val) => acc + val, 0)
 );
+```
+
+Using the memoize function from lodash for an unbounded cache:
+
+```js
+import { createSelectorCreator } from 'reselect';
+import memoize from 'lodash.memoize';
+
+
+let called = 0;
+const customSelectorCreator = createSelectorCreator(memoize, JSON.stringify);
+const selector = customSelectorCreator(
+  state => state.a,
+  state => state.b,
+  (a, b) => {
+    called++;
+    return a + b;
+  }
+);
+assert.equal(selector({a: 1, b: 2}), 3);
+assert.equal(selector({a: 1, b: 2}), 3);
+assert.equal(called, 1);
+assert.equal(selector({a: 2, b: 3}), 5);
+assert.equal(called, 2);
 ```

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "compile": "babel -d lib/ src/",
+    "lint": "eslint src test",
     "prepublish": "npm run compile",
     "test": "NODE_ENV=test mocha --compilers js:babel/register --recursive",
     "test:cov": "babel-node ./node_modules/.bin/isparta cover ./node_modules/.bin/_mocha -- --recursive"
@@ -35,6 +36,21 @@
     },
     {
       "name": "Philip Spitzlinger"
+    },
+    {
+      "name": "Alex Guerra"
+    },
+    {
+      "name": "ryanatkn"
+    }, 
+    {
+      "name": "Adam Royle"
+    }, 
+    {
+      "name": "Christian Schuhmann"
+    }, 
+    {
+      "name": "Jason Huang"
     }
   ],
   "repository": {
@@ -45,6 +61,9 @@
   "devDependencies": {
     "babel": "^5.5.8",
     "babel-core": "^5.6.15",
+    "babel-eslint": "^3.1.15",
+    "eslint": "^0.23",
+    "eslint-config-airbnb": "0.0.6",
     "chai": "^3.0.0",
     "isparta": "^3.0.3",
     "lodash.memoize": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "package.json"
   ],
   "bugs": {
-    "url" : "https://github.com/faassen/reselect/issues"
+    "url": "https://github.com/faassen/reselect/issues"
   },
   "scripts": {
     "compile": "babel -d lib/ src/",
@@ -23,15 +23,20 @@
     "redux"
   ],
   "author": "Martijn Faassen",
-  "contributors": [{
-    "name": "Martijn Faassen"
-  }, {
-    "name": "Lee Bannard"
-  }, {
-    "name": "Robert Binna"
-  }, {
-    "name": "Philip Spitzlinger"
-  }],
+  "contributors": [
+    {
+      "name": "Martijn Faassen"
+    },
+    {
+      "name": "Lee Bannard"
+    },
+    {
+      "name": "Robert Binna"
+    },
+    {
+      "name": "Philip Spitzlinger"
+    }
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/faassen/reselect.git"
@@ -42,6 +47,7 @@
     "babel-core": "^5.6.15",
     "chai": "^3.0.0",
     "isparta": "^3.0.3",
+    "lodash.memoize": "^3.0.4",
     "mocha": "^2.2.5"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ export function createSelectorCreator(valueEquals) {
         if (!Array.isArray(selectors)) {
             selectors = [selectors];
         }
-        const memoizedResultFunc = memoize(resultFunc, valueEquals);
+        const memoizedResultFunc = internalMemoize(resultFunc, valueEquals);
         return state => {
             const params = selectors.map(selector => selector(state));
             return memoizedResultFunc(params);
@@ -19,12 +19,17 @@ export function defaultValueEquals(a, b) {
     return a === b;
 }
 
+export function memoize(func, valueEquals = defaultValueEquals) {
+   let memoizedFunc = internalMemoize(func, valueEquals);
+   return (...args) => memoizedFunc(args);
+}
+
 // the memoize function only caches one set of arguments.  This
 // actually good enough, rather surprisingly. This is because during
 // calculation of a selector result the arguments won't
 // change if called multiple times. If a new state comes in, we *want*
 // recalculation if and only if the arguments are different.
-function memoize(func, valueEquals) {
+function internalMemoize(func, valueEquals) {
     let lastArgs = null;
     let lastResult = null;
     return (args) => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,20 +1,3 @@
-export function createSelectorCreator(memoize = defaultMemoize, ...memoizeOptions) {
-    return (...selectors) => {
-        const memoizedResultFunc = memoize(selectors.pop(), ...memoizeOptions);
-        if (Array.isArray(selectors[0])) {
-            selectors = selectors[0];
-        }
-        return (state, props) => {
-            const params = selectors.map(selector => selector(state, props));
-            return memoizedResultFunc(...params, props);
-        }
-    };
-}
-
-export function createSelector(...args) {
-    return createSelectorCreator(defaultMemoize)(...args);
-}
-
 function defaultValuesEqual(a, b) {
     return a === b;
 }
@@ -32,5 +15,22 @@ export function defaultMemoize(func, valuesEqual = defaultValuesEqual) {
         lastArgs = args;
         lastResult = func(...args, props);
         return lastResult;
-    }
+    };
 }
+
+export function createSelectorCreator(memoize = defaultMemoize, ...memoizeOptions) {
+    return (...dependencies) => {
+        const memoizedResultFunc = memoize(dependencies.pop(), ...memoizeOptions);
+        const selectors = Array.isArray(dependencies[0]) ?
+            dependencies[0] : dependencies;
+        return (state, props) => {
+            const params = selectors.map(selector => selector(state, props));
+            return memoizedResultFunc(...params, props);
+        };
+    };
+}
+
+export function createSelector(...args) {
+    return createSelectorCreator(defaultMemoize)(...args);
+}
+

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ export function createSelectorCreator(memoize = defaultMemoize) {
         }
         return (state, props) => {
             const params = selectors.map(selector => selector(state, props));
-            return memoizedResultFunc(params, props);
+            return memoizedResultFunc(...params, props);
         }
     };
 }
@@ -23,7 +23,8 @@ function defaultValuesEqual(a, b) {
 export function defaultMemoize(func, valuesEqual = defaultValuesEqual) {
     let lastArgs = null;
     let lastResult = null;
-    return (args, props) => {
+    return (...args) => {
+        const props = args.pop();
         if (lastArgs !== null &&
             args.every((value, index) => valuesEqual(value, lastArgs[index]))) {
             return lastResult;
@@ -35,9 +36,9 @@ export function defaultMemoize(func, valuesEqual = defaultValuesEqual) {
 }
 
 // Wrap external memoize function for use with reselect
-export function wrapMemoize(memoize) {
+export function wrapMemoize(memoize, ...options) {
   return func => {
-    const memoized = memoize(func);
-    return (args, props) => memoized(...args, props);
+    const memoized = memoize(func, ...options);
+    return (...args) => memoized(...args);
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,39 +1,39 @@
-export function createSelectorCreator(memoize = internalMemoize) {
+export function createSelectorCreator(memoize = defaultMemoize) {
     return (...selectors) => {
         const memoizedResultFunc = memoize(selectors.pop());
         if (Array.isArray(selectors[0])) {
             selectors = selectors[0];
         }
-        return state => {
-            const params = selectors.map(selector => selector(state));
-            return memoizedResultFunc(params);
+        return (state, props) => {
+            const params = selectors.map(selector => selector(state, props));
+            return memoizedResultFunc(params, props);
         }
     };
 }
 
 export function createSelector(...args) {
-    return createSelectorCreator(internalMemoize)(...args);
+    return createSelectorCreator(defaultMemoize)(...args);
 }
 
-function defaultShouldUpdate(a, b) {
+function defaultValuesEqual(a, b) {
     return a === b;
 }
 
-export function createMemoize(shouldUpdate = defaultShouldUpdate) {
-    return func => internalMemoize(func, shouldUpdate);
-}
-
 // TODO: Reintroduce comment, slightly rewritten
-function internalMemoize(func, shouldUpdate = defaultShouldUpdate) {
+export function defaultMemoize(func, valuesEqual = defaultValuesEqual) {
     let lastArgs = null;
     let lastResult = null;
-    return (args) => {
+    return (args, props) => {
         if (lastArgs !== null &&
-            args.every((value, index) => shouldUpdate(value, lastArgs[index]))) {
+            args.every((value, index) => valuesEqual(value, lastArgs[index]))) {
             return lastResult;
         }
         lastArgs = args;
-        lastResult = func(...args);
+        lastResult = func(...args, props);
         return lastResult;
     }
+}
+
+export function wrapMemoize(memoize) {
+  return (...args) => memoize(args);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,10 @@ export function defaultMemoize(func, valuesEqual = defaultValuesEqual) {
     }
 }
 
+// Wrap external memoize function for use with reselect
 export function wrapMemoize(memoize) {
-  return (...args) => memoize(args);
+  return func => {
+    const memoized = memoize(func);
+    return (args, props) => memoized(...args, props);
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
-export function createSelectorCreator(memoize = defaultMemoize) {
+export function createSelectorCreator(memoize = defaultMemoize, ...memoizeOptions) {
     return (...selectors) => {
-        const memoizedResultFunc = memoize(selectors.pop());
+        const memoizedResultFunc = memoize(selectors.pop(), ...memoizeOptions);
         if (Array.isArray(selectors[0])) {
             selectors = selectors[0];
         }
@@ -33,12 +33,4 @@ export function defaultMemoize(func, valuesEqual = defaultValuesEqual) {
         lastResult = func(...args, props);
         return lastResult;
     }
-}
-
-// Wrap external memoize function for use with reselect
-export function wrapMemoize(memoize, ...options) {
-  return func => {
-    const memoized = memoize(func, ...options);
-    return (...args) => memoized(...args);
-  }
 }

--- a/test/test_selector.js
+++ b/test/test_selector.js
@@ -1,33 +1,36 @@
 import chai from 'chai';
-import { createSelector, createSelectorCreator, memoize } from '../src/index';
+import { createSelector, createSelectorCreator, createMemoize } from '../src/index';
 
 let assert = chai.assert;
 
 suite('selector', function() {
     test("basic selector", function() {
-        const selector = createSelector([state => state.a], a => a);
+        const selector = createSelector(state => state.a, a => a);
         assert.equal(selector({a: 1}), 1);
     });
     test("basic selector multiple keys", function() {
         const selector = createSelector(
-            [state => state.a, state => state.b], (a, b) => a + b);
+            state => state.a,
+            state => state.b,
+            (a, b) => a + b
+        );
         assert.equal(selector({a: 1, b: 2}), 3);
     });
-    test("first argument does not need to be an array", function() {
+    test("first argument can be an array", function() {
         const selector = createSelector(
-            state => state.a, a => a);
+            [state => state.a], a => a);
         assert.equal(selector({a: 1}), 1);
     });
     test("chained selector", function() {
         const selector1 = createSelector(
-            [state => state.sub], sub => sub);
+            state => state.sub, sub => sub);
         const selector2 = createSelector(
-            [selector1], sub => sub.value);
+            selector1, sub => sub.value);
         assert.equal(selector2({sub: { value: 1}}), 1);
     });
     test("memoized selector", function() {
         let called = 0;
-        const selector = createSelector([state => state.a], a => {
+        const selector = createSelector(state => state.a, a => {
             called++;
             return a;
         });
@@ -39,7 +42,7 @@ suite('selector', function() {
     });
     test("memoized composite arguments", function() {
         let called = 0;
-        const selector = createSelector([state => state.sub], sub => {
+        const selector = createSelector(state => state.sub, sub => {
             called++;
             return sub;
         });
@@ -54,10 +57,10 @@ suite('selector', function() {
     });
     test("override valueEquals", function() {
         // a rather absurd equals operation we can verify in tests
-        const createSelector = createSelectorCreator(
-            (a, b) => typeof a === typeof b);
+        const memoize = createMemoize((a, b) => typeof a === typeof b);
+        const createSelector = createSelectorCreator(memoize);
         let called = 0;
-        const selector = createSelector([state => state.a], a => {
+        const selector = createSelector(state => state.a, a => {
             called++;
             return a;
         });
@@ -69,30 +72,30 @@ suite('selector', function() {
     });
     test("exported memoize", function() {
         let called = 0;
-        const memoized = memoize(state => {
+        const memoized = createMemoize()(state => {
             called++;
             return state.a;
         });
         const o1 = {a: 1};
         const o2 = {a: 2};
-        assert.equal(memoized(o1), 1);
-        assert.equal(memoized(o1), 1);
+        assert.equal(memoized([o1]), 1);
+        assert.equal(memoized([o1]), 1);
         assert.equal(called, 1);
-        assert.equal(memoized(o2), 2);
+        assert.equal(memoized([o2]), 2);
         assert.equal(called, 2);
     });
     test("exported memoize with valueEquals override", function() {
         // a rather absurd equals operation we can verify in tests
         const valueEquals = (a, b) => typeof a === typeof b;
         let called = 0;
-        const memoized = memoize(a => {
+        const memoized = createMemoize(valueEquals)(a => {
             called++;
             return a;
-        }, valueEquals);
-        assert.equal(memoized(1), 1);
-        assert.equal(memoized(2), 1); // yes, really true
+        });
+        assert.equal(memoized([1]), 1);
+        assert.equal(memoized([2]), 1); // yes, really true
         assert.equal(called, 1);
-        assert.equal(memoized('A'), 'A');
+        assert.equal(memoized(['A']), 'A');
         assert.equal(called, 2);
     });
 });

--- a/test/test_selector.js
+++ b/test/test_selector.js
@@ -1,15 +1,15 @@
 import chai from 'chai';
 import { createSelector, createSelectorCreator, defaultMemoize } from '../src/index';
-import memoize from 'lodash.memoize';
+import { default as lodashMemoize } from 'lodash.memoize';
 
 let assert = chai.assert;
 
-suite('selector', function() {
-    test("basic selector", function() {
+suite('selector', () => {
+    test('basic selector', () => {
         const selector = createSelector(state => state.a, a => a);
         assert.equal(selector({a: 1}), 1);
     });
-    test("basic selector multiple keys", function() {
+    test('basic selector multiple keys', () => {
         const selector = createSelector(
             state => state.a,
             state => state.b,
@@ -17,12 +17,12 @@ suite('selector', function() {
         );
         assert.equal(selector({a: 1, b: 2}), 3);
     });
-    test("first argument can be an array", function() {
+    test('first argument can be an array', () => {
         const selector = createSelector(
             [state => state.a], a => a);
         assert.equal(selector({a: 1}), 1);
     });
-    test("can accept props", function() {
+    test('can accept props', () => {
         const selector = createSelector(
             state => state.a,
             state => state.b,
@@ -30,13 +30,13 @@ suite('selector', function() {
         );
         assert.equal(selector({a: 1, b: 2}, 100), 103);
     });
-    test("ignores props for default memoization", function() {
+    test('ignores props for default memoization', () => {
         let called = 0;
         const selector = createSelector(
             state => state.a,
             (a, b) => {
                 called++;
-                return a + b
+                return a + b;
             }
         );
         assert.equal(selector({a: 1}, 100), 101);
@@ -45,14 +45,14 @@ suite('selector', function() {
         assert.equal(selector({a: 2}, 200), 202);
         assert.equal(called, 2);
     });
-    test("chained selector", function() {
+    test('chained selector', () => {
         const selector1 = createSelector(
             state => state.sub, sub => sub);
         const selector2 = createSelector(
             selector1, sub => sub.value);
         assert.equal(selector2({sub: { value: 1}}), 1);
     });
-    test("memoized selector", function() {
+    test('memoized selector', () => {
         let called = 0;
         const selector = createSelector(state => state.a, a => {
             called++;
@@ -64,7 +64,7 @@ suite('selector', function() {
         assert.equal(selector({a: 2}), 2);
         assert.equal(called, 2);
     });
-    test("memoized composite arguments", function() {
+    test('memoized composite arguments', () => {
         let called = 0;
         const selector = createSelector(state => state.sub, sub => {
             called++;
@@ -75,12 +75,14 @@ suite('selector', function() {
         assert.deepEqual(selector(state), { a: 1 });
         assert.equal(called, 1);
     });
-    test("override valueEquals", function() {
+    test('override valueEquals', () => {
         // a rather absurd equals operation we can verify in tests
-        const memoize = (func) => defaultMemoize(func, (a, b) => typeof a === typeof b);
-        const createSelector = createSelectorCreator(memoize);
+        const createOverridenSelector = createSelectorCreator(
+          defaultMemoize,
+          (a, b) => typeof a === typeof b
+        );
         let called = 0;
-        const selector = createSelector(state => state.a, a => {
+        const selector = createOverridenSelector(state => state.a, a => {
             called++;
             return a;
         });
@@ -90,9 +92,9 @@ suite('selector', function() {
         assert.equal(selector({a: 'A'}), 'A');
         assert.equal(called, 2);
     });
-    test("custom memoize", function() {
+    test('custom memoize', () => {
         let called = 0;
-        const customSelectorCreator = createSelectorCreator(memoize, JSON.stringify);
+        const customSelectorCreator = createSelectorCreator(lodashMemoize, JSON.stringify);
         const selector = customSelectorCreator(
             state => state.a,
             state => state.b,
@@ -106,9 +108,9 @@ suite('selector', function() {
         assert.equal(called, 1);
         assert.equal(selector({a: 2, b: 3}), 5);
         assert.equal(called, 2);
-        //TODO: Check that defaultMemoize hasn't been called
+        // TODO: Check correct memoize function was called
     });
-    test("exported memoize", function() {
+    test('exported memoize', () => {
         let called = 0;
         const memoized = defaultMemoize(state => {
             called++;
@@ -122,7 +124,7 @@ suite('selector', function() {
         assert.equal(memoized(o2, {}), 2);
         assert.equal(called, 2);
     });
-    test("exported memoize with valueEquals override", function() {
+    test('exported memoize with valueEquals override', () => {
         // a rather absurd equals operation we can verify in tests
         const valueEquals = (a, b) => typeof a === typeof b;
         let called = 0;

--- a/test/test_selector.js
+++ b/test/test_selector.js
@@ -1,5 +1,5 @@
 import chai from 'chai';
-import { createSelector, createSelectorCreator, defaultMemoize, wrapMemoize } from '../src/index';
+import { createSelector, createSelectorCreator, defaultMemoize } from '../src/index';
 import memoize from 'lodash.memoize';
 
 let assert = chai.assert;
@@ -91,9 +91,8 @@ suite('selector', function() {
         assert.equal(called, 2);
     });
     test("custom memoize", function() {
-        const customMemoize = wrapMemoize((func) => memoize(func, JSON.stringify));
         let called = 0;
-        const customSelectorCreator = createSelectorCreator(customMemoize);
+        const customSelectorCreator = createSelectorCreator(memoize, JSON.stringify);
         const selector = customSelectorCreator(
             state => state.a,
             state => state.b,
@@ -111,8 +110,7 @@ suite('selector', function() {
     });
     test("exported memoize", function() {
         let called = 0;
-        const wrappedDefault = wrapMemoize(defaultMemoize);
-        const memoized = wrappedDefault(state => {
+        const memoized = defaultMemoize(state => {
             called++;
             return state.a;
         });
@@ -128,11 +126,10 @@ suite('selector', function() {
         // a rather absurd equals operation we can verify in tests
         const valueEquals = (a, b) => typeof a === typeof b;
         let called = 0;
-        const wrappedDefault = wrapMemoize(defaultMemoize, valueEquals);
-        const memoized = wrappedDefault(a => {
+        const memoized = defaultMemoize(a => {
             called++;
             return a;
-        });
+        }, valueEquals);
         assert.equal(memoized(1, {}), 1);
         assert.equal(memoized(2, {}), 1); // yes, really true
         assert.equal(called, 1);

--- a/test/test_selector.js
+++ b/test/test_selector.js
@@ -111,32 +111,32 @@ suite('selector', function() {
     });
     test("exported memoize", function() {
         let called = 0;
-        const memoized = defaultMemoize(state => {
+        const wrappedDefault = wrapMemoize(defaultMemoize);
+        const memoized = wrappedDefault(state => {
             called++;
             return state.a;
         });
-        const wrapped = (...args) => memoized(args);
         const o1 = {a: 1};
         const o2 = {a: 2};
-        assert.equal(wrapped(o1), 1);
-        assert.equal(wrapped(o1), 1);
+        assert.equal(memoized(o1, {}), 1);
+        assert.equal(memoized(o1, {}), 1);
         assert.equal(called, 1);
-        assert.equal(wrapped(o2), 2);
+        assert.equal(memoized(o2, {}), 2);
         assert.equal(called, 2);
     });
     test("exported memoize with valueEquals override", function() {
         // a rather absurd equals operation we can verify in tests
         const valueEquals = (a, b) => typeof a === typeof b;
         let called = 0;
-        const memoized = defaultMemoize(a => {
+        const wrappedDefault = wrapMemoize(defaultMemoize, valueEquals);
+        const memoized = wrappedDefault(a => {
             called++;
             return a;
-        }, valueEquals);
-        const wrapped = (...args) => memoized(args);
-        assert.equal(wrapped(1), 1);
-        assert.equal(wrapped(2), 1); // yes, really true
+        });
+        assert.equal(memoized(1, {}), 1);
+        assert.equal(memoized(2, {}), 1); // yes, really true
         assert.equal(called, 1);
-        assert.equal(wrapped('A'), 'A');
+        assert.equal(memoized('A', {}), 'A');
         assert.equal(called, 2);
     });
 });

--- a/test/test_selector.js
+++ b/test/test_selector.js
@@ -1,5 +1,5 @@
 import chai from 'chai';
-import { createSelector, createSelectorCreator, createMemoize } from '../src/index';
+import { createSelector, createSelectorCreator, defaultMemoize, wrapMemoize } from '../src/index';
 
 let assert = chai.assert;
 
@@ -20,6 +20,29 @@ suite('selector', function() {
         const selector = createSelector(
             [state => state.a], a => a);
         assert.equal(selector({a: 1}), 1);
+    });
+    test("can accept props", function() {
+        const selector = createSelector(
+            state => state.a, 
+            state => state.b,
+            (a, b, props) => a + b + props
+        );
+        assert.equal(selector({a: 1, b: 2}, 100), 103);
+    });
+    test("ignores props for default memoization", function() {
+        let called = 0;
+        const selector = createSelector(
+            state => state.a, 
+            (a, b) => {
+                called++;
+                return a + b
+            }
+        );
+        assert.equal(selector({a: 1}, 100), 101);
+        assert.equal(selector({a: 1}, 200), 101);
+        assert.equal(called, 1);
+        assert.equal(selector({a: 2}, 200), 202);
+        assert.equal(called, 2);
     });
     test("chained selector", function() {
         const selector1 = createSelector(
@@ -46,18 +69,14 @@ suite('selector', function() {
             called++;
             return sub;
         });
-        const state = {
-            sub: {
-                a: 1
-            }
-        };
+        const state = { sub: { a: 1 } };
         assert.deepEqual(selector(state), { a: 1 });
         assert.deepEqual(selector(state), { a: 1 });
         assert.equal(called, 1);
     });
     test("override valueEquals", function() {
         // a rather absurd equals operation we can verify in tests
-        const memoize = createMemoize((a, b) => typeof a === typeof b);
+        const memoize = (func) => defaultMemoize(func, (a, b) => typeof a === typeof b);
         const createSelector = createSelectorCreator(memoize);
         let called = 0;
         const selector = createSelector(state => state.a, a => {
@@ -72,30 +91,30 @@ suite('selector', function() {
     });
     test("exported memoize", function() {
         let called = 0;
-        const memoized = createMemoize()(state => {
+        const memoized = wrapMemoize(defaultMemoize(state => {
             called++;
             return state.a;
-        });
+        }));
         const o1 = {a: 1};
         const o2 = {a: 2};
-        assert.equal(memoized([o1]), 1);
-        assert.equal(memoized([o1]), 1);
+        assert.equal(memoized(o1), 1);
+        assert.equal(memoized(o1), 1);
         assert.equal(called, 1);
-        assert.equal(memoized([o2]), 2);
+        assert.equal(memoized(o2), 2);
         assert.equal(called, 2);
     });
     test("exported memoize with valueEquals override", function() {
         // a rather absurd equals operation we can verify in tests
         const valueEquals = (a, b) => typeof a === typeof b;
         let called = 0;
-        const memoized = createMemoize(valueEquals)(a => {
+        const memoized = wrapMemoize(defaultMemoize(a => {
             called++;
             return a;
-        });
-        assert.equal(memoized([1]), 1);
-        assert.equal(memoized([2]), 1); // yes, really true
+        }, valueEquals));
+        assert.equal(memoized(1), 1);
+        assert.equal(memoized(2), 1); // yes, really true
         assert.equal(called, 1);
-        assert.equal(memoized(['A']), 'A');
+        assert.equal(memoized('A'), 'A');
         assert.equal(called, 2);
     });
 });

--- a/test/test_selector.js
+++ b/test/test_selector.js
@@ -1,5 +1,5 @@
 import chai from 'chai';
-import {createSelector, createSelectorCreator} from '../src/index';
+import { createSelector, createSelectorCreator, memoize } from '../src/index';
 
 let assert = chai.assert;
 
@@ -65,6 +65,34 @@ suite('selector', function() {
         assert.equal(selector({a: 2}), 1); // yes, really true
         assert.equal(called, 1);
         assert.equal(selector({a: 'A'}), 'A');
+        assert.equal(called, 2);
+    });
+    test("exported memoize", function() {
+        let called = 0;
+        const memoized = memoize(state => {
+            called++;
+            return state.a;
+        });
+        const o1 = {a: 1};
+        const o2 = {a: 2};
+        assert.equal(memoized(o1), 1);
+        assert.equal(memoized(o1), 1);
+        assert.equal(called, 1);
+        assert.equal(memoized(o2), 2);
+        assert.equal(called, 2);
+    });
+    test("exported memoize with valueEquals override", function() {
+        // a rather absurd equals operation we can verify in tests
+        const valueEquals = (a, b) => typeof a === typeof b;
+        let called = 0;
+        const memoized = memoize(a => {
+            called++;
+            return a;
+        }, valueEquals);
+        assert.equal(memoized(1), 1);
+        assert.equal(memoized(2), 1); // yes, really true
+        assert.equal(called, 1);
+        assert.equal(memoized('A'), 'A');
         assert.equal(called, 2);
     });
 });


### PR DESCRIPTION
Work in progress experiments to address issues #7 , #20 , #27. The API section of the README has some examples.

There is one breaking change. `createSelectorCreator` now takes a memoize function instead of a valueEquals function.