### PR TITLE
WIP 1.0.0 (Configurable memoize / variadic dependencies / pass props to selector)

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,9 @@ export default connect(visibleTodosSelector)(App);
 
 ### Accessing React Props in Selectors
 
-The following code shows a modification to `index.js` where a `maxTodos` prop is being passed to the `App` component that specifies the maximum number of Todos to be displayed at any one time:
+So far our selectors have only been receiving the Redux store as input. It is also possible to pass the props of a component wrapped by `connect` into a selector.
+
+Consider the following example:
 
 #### `index.js`
 
@@ -274,7 +276,7 @@ React.render(
 
 ```
 
-When a selector is connected to a component with `connect`, the component props are passed as the second argument to the selector. We will use this fact to access the `maxTodos` prop from within `visibleTodosSelector`. First, we create a new input-selector named `maxTodosSelector` which gets `maxTodos` from its props argument (and ignores its state argument). Then we add `maxTodosSelector` as an input selector to `visibleTodosSelector`:
+The prop `maxTodos` has been added to the `App` component. We would like to access this prop in `visibleTodosSelector` so we change `selectors/todoSelectors.js` to the following:
 
 #### `selectors/todoSelectors.js`
 
@@ -295,7 +297,6 @@ function selectTodos(todos, filter) {
 
 const visibilityFilterSelector = state => state.visibilityFilter;
 const todosSelector = state => state.todos;
-// accessing props via the second argument
 const maxTodosSelector = (_, props) => props.maxTodos;
 
 export const visibleTodosSelector = createSelector(
@@ -311,6 +312,8 @@ export const visibleTodosSelector = createSelector(
   }
 );
 ```
+
+When a selector is connected to a component with `connect`, the component props are passed as the second argument to the selector. In the example above, we added a new input-selector named `maxTodosSelector` which gets `maxTodos` from its props argument (and ignores its state argument). `maxTodosSelector` was then added as an input selector to `visibleTodosSelector`, making `maxTodos` available to the selectors result function.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ export const totalSelector = createSelector(
 
 ### Motivation for Memoized Selectors
 
-> The examples in this section are based on the [Redux Todos List example](https://github.com/docs/basics/UsageWithReact.md).
+> The examples in this section are based on the [Redux Todos List example](http://rackt.github.io/redux/docs/basics/UsageWithReact.html).
 
 Consider the following code:
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ export const totalSelector = createSelector(
 
 ### Motivation for Memoized Selectors
 
-Here is `App.js` from the [Redux Todos List example](https://github.com/docs/basics/UsageWithReact.md):
+> The examples in this section are based on the [Redux Todos List example](https://github.com/docs/basics/UsageWithReact.md).
+
+Consider the following code:
 
 #### `containers/App.js`
 
@@ -165,7 +167,6 @@ function selectTodos(todos, filter) {
  * of the store in cases where no calculations are needed 
  * and memoization wouldn't provide any benefits.
  */
-
 const visibilityFilterSelector = state => state.visibilityFilter;
 const todosSelector = state => state.todos;
 
@@ -176,7 +177,6 @@ const todosSelector = state => state.todos;
  * Hence, these selectors are only recomputed when the value of their input selectors change. 
  * If none of the input selectors return a new value, the previously computed value is returned.
  */
- 
 export const visibleTodosSelector = createSelector(
   visibilityFilterSelector,
   todosSelector,
@@ -224,7 +224,6 @@ import Footer from '../components/Footer';
  * Import the selector defined in ../selectors/todoSelectors.js.
  * This allows you to separate your components from the structure of your stores.
  */
-
 import { visibleTodosSelector } from '../selectors/todoSelectors';
 
 class App extends Component {
@@ -265,7 +264,7 @@ App.propTypes = {
 };
 
 /*
- * Bind the visibleTodosSelector to the App component.
+ * Connet visibleTodosSelector to the App component.
  * The keys of the selector result are available on the props object for App.
  * In our example there is the 'visibleTodos' key which is bound to this.props.visibleTodos
  */

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ const todosSelector = state => state.todos;
 /* 
  * Definition of combined selector. 
  * In visibleTodosSelector, input selectors are combined to derive new information. 
- * To prevent expensive recalculation of the input-selectors memoization is applied. 
+ * To prevent expensive recalculation of the input selectors memoization is applied. 
  * Hence, these selectors are only recomputed when the value of their input selectors change. 
  * If none of the input selectors return a new value, the previously computed value is returned.
  */

--- a/README.md
+++ b/README.md
@@ -159,9 +159,24 @@ function selectTodos(todos, filter) {
   }
 }
 
+/*
+ * Definition of input selectors. 
+ * Input selectors should be used to abstract away the structure
+ * of the store in cases where no calculations are needed 
+ * and memoization wouldn't provide any benefits.
+ */
+
 const visibilityFilterSelector = state => state.visibilityFilter;
 const todosSelector = state => state.todos;
 
+/* 
+ * Definition of combined selector. 
+ * In visibleTodosSelector, input selectors are combined to derive new information. 
+ * To prevent expensive recalculation of the input-selectors memoization is applied. 
+ * Hence, these selectors are only recomputed when the value of their input selectors change. 
+ * If none of the input selectors return a new value, the previously computed value is returned.
+ */
+ 
 export const visibleTodosSelector = createSelector(
   visibilityFilterSelector,
   todosSelector,
@@ -204,6 +219,12 @@ import { addTodo, completeTodo, setVisibilityFilter } from '../actions';
 import AddTodo from '../components/AddTodo';
 import TodoList from '../components/TodoList';
 import Footer from '../components/Footer';
+
+/*
+ * Import the selector defined in ../selectors/todoSelectors.js.
+ * This allows you to separate your components from the structure of your stores.
+ */
+
 import { visibleTodosSelector } from '../selectors/todoSelectors';
 
 class App extends Component {
@@ -243,7 +264,11 @@ App.propTypes = {
   ]).isRequired
 };
 
-// Pass the selector to the connect component
+/*
+ * Bind the visibleTodosSelector to the App component.
+ * The keys of the selector result are available on the props object for App.
+ * In our example there is the 'visibleTodos' key which is bound to this.props.visibleTodos
+ */
 export default connect(visibleTodosSelector)(App);
 ```
 
@@ -266,8 +291,6 @@ let store = createStore(todoApp);
 
 let rootElement = document.getElementById('root');
 React.render(
-  // The child must be wrapped in a function
-  // to work around an issue in React 0.13.
   <Provider store={store}>
     {() => <App maxTodos={5}/>}
   </Provider>,


### PR DESCRIPTION
Work in progress experiments to address issues #7 , #20 , #27. The API section of the README has some examples.

There is one breaking change. createSelectorCreator now takes a memoize function instead of a valueEquals function.