### PR TITLE
Validate input selectors on selector creation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,11 @@ export function createSelectorCreator(memoize, ...memoizeOptions) {
             return memoizedResultFunc(...params);
         };
 
+        if (!dependencies.every(dependency => typeof dependency === 'function')) {
+            const dependencyTypes = dependencies.map(dep => typeof dep).join(', ');
+            throw new Error('Selector creator inputs must be functions, got: ' + dependencyTypes);
+        }
+
         selector.recomputations = () => recomputations;
         return selector;
     };

--- a/test/test_selector.js
+++ b/test/test_selector.js
@@ -33,6 +33,15 @@ suite('selector', () => {
         assert.equal(selector(state2), 5);
         assert.equal(selector.recomputations(), 2);
     });
+    test('basic selector invalid input selector', () => {
+        const selector = createSelector.bind(
+            void 0,
+            state => state.a,
+            'not a function',
+            (a, b) => a + b
+        );
+        assert.throw(selector, 'got: function, string');
+    });
     test('memoized composite arguments', () => {
         const selector = createSelector(
             state => state.sub,


### PR DESCRIPTION
### Rationale

I ran into an issue while working on some selectors where an input selector was undefined.  However, the error is thrown only when the selector is used and does not provide a terribly useful stack trace.  Checking the input selectors on selector creation:

* Fails sooner, when the selector is originally created
* Provides us a stack trace directly to the problematic code

### Solution

A very basic `typeof` check to ensure than input selectors are functions.

### Changes

* Ensure input selectors are functions during selector creation
* Throw if invalid, allowing for a useful stack trace